### PR TITLE
Add .worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ yarn-error.log*
 .env
 .env.local
 .env.*.local
+
+# Git worktrees (for developers using worktree workflow)
+.worktrees/


### PR DESCRIPTION
## Summary
- Added `.worktrees/` directory to `.gitignore` to support developers using git worktrees with local organization

## Changes
- Added `.worktrees/` pattern to `.gitignore` with explanatory comment
- Supports developers who prefer organizing worktrees in a `.worktrees/` subdirectory within the main repository
- No impact on developers who use other worktree organizational patterns

## Test plan
- [x] Created `.worktrees/` directory with test files
- [x] Verified git status correctly ignores the directory
- [x] Confirmed only `.gitignore` changes are tracked

## What was accomplished
- All tasks from issue #10 completed
- `.worktrees/` pattern added to `.gitignore` (line 67)
- Pattern tested and verified working correctly
- Using the new worktree location ourselves for this implementation

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)