### PR TITLE
Phase 1.4: CLI & Entry Point

### DIFF
--- a/packages/mcp-server/src/claude_session_coordinator/__main__.py
+++ b/packages/mcp-server/src/claude_session_coordinator/__main__.py
@@ -3,17 +3,179 @@
 Run with: python -m claude_session_coordinator
 """
 
+import argparse
 import asyncio
 import sys
+from typing import Optional
 
+from . import __version__
+from .config import load_config, get_default_config
 from .server import main
 
-if __name__ == "__main__":
+
+def create_parser() -> argparse.ArgumentParser:
+    """Create the argument parser for the CLI.
+
+    Returns:
+        Configured ArgumentParser instance
+    """
+    parser = argparse.ArgumentParser(
+        prog="claude-session-coordinator",
+        description="MCP server for coordinating multiple Claude AI sessions",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Start the MCP server (default)
+  python -m claude_session_coordinator
+
+  # Show version
+  python -m claude_session_coordinator --version
+
+  # Validate configuration
+  python -m claude_session_coordinator --validate-config
+
+For more information, visit:
+  https://github.com/BANCS-Norway/claude_session_coordinator
+        """
+    )
+
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+        help="show version and exit"
+    )
+
+    parser.add_argument(
+        "--validate-config",
+        action="store_true",
+        help="validate configuration and exit"
+    )
+
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="enable verbose logging"
+    )
+
+    return parser
+
+
+def validate_config() -> int:
+    """Validate the configuration.
+
+    Returns:
+        Exit code (0 for success, 1 for errors)
+    """
+    print("Validating configuration...")
+
     try:
+        # Load configuration
+        config = load_config()
+
+        print("✓ Configuration loaded successfully")
+
+        # Validate required fields
+        if "storage" not in config:
+            print("✗ Error: 'storage' section missing from configuration")
+            return 1
+
+        if "adapter" not in config["storage"]:
+            print("✗ Error: 'storage.adapter' not specified")
+            return 1
+
+        adapter_type = config["storage"]["adapter"]
+        print(f"✓ Storage adapter: {adapter_type}")
+
+        if "config" not in config["storage"]:
+            print("✗ Error: 'storage.config' section missing")
+            return 1
+
+        print(f"✓ Storage configuration: {config['storage']['config']}")
+
+        # Validate session configuration
+        if "session" in config:
+            machine_id = config["session"].get("machine_id", "auto")
+            project_detection = config["session"].get("project_detection", "git")
+            print(f"✓ Machine ID: {machine_id}")
+            print(f"✓ Project detection: {project_detection}")
+        else:
+            print("✓ Using default session configuration")
+
+        # Try to import the adapter
+        from .adapters import AdapterFactory
+
+        # Test adapter creation
+        try:
+            adapter = AdapterFactory.create_adapter(config["storage"])
+            print(f"✓ Adapter '{adapter_type}' loaded successfully")
+            adapter.close()
+        except Exception as e:
+            print(f"✗ Error loading adapter: {e}")
+            return 1
+
+        print("\n✓ Configuration is valid!")
+        return 0
+
+    except FileNotFoundError as e:
+        print(f"✗ Configuration file not found: {e}")
+        print("\nUsing default configuration:")
+        default_config = get_default_config()
+        import json
+        print(json.dumps(default_config, indent=2))
+        print("\n✓ Default configuration is valid")
+        return 0
+    except Exception as e:
+        print(f"✗ Error validating configuration: {e}")
+        return 1
+
+
+def run_server(verbose: bool = False) -> int:
+    """Run the MCP server.
+
+    Args:
+        verbose: Enable verbose logging
+
+    Returns:
+        Exit code (0 for success, non-zero for errors)
+    """
+    try:
+        if verbose:
+            print("Starting Claude Session Coordinator MCP server...", file=sys.stderr)
+
         asyncio.run(main())
+        return 0
+
     except KeyboardInterrupt:
         print("\nShutting down Claude Session Coordinator...", file=sys.stderr)
-        sys.exit(0)
+        return 0
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
-        sys.exit(1)
+        if verbose:
+            import traceback
+            traceback.print_exc()
+        return 1
+
+
+def cli_main(argv: Optional[list[str]] = None) -> int:
+    """Main CLI entry point.
+
+    Args:
+        argv: Command-line arguments (defaults to sys.argv)
+
+    Returns:
+        Exit code
+    """
+    parser = create_parser()
+    args = parser.parse_args(argv)
+
+    # Handle --validate-config
+    if args.validate_config:
+        return validate_config()
+
+    # Default: run the server
+    return run_server(verbose=args.verbose)
+
+
+if __name__ == "__main__":
+    sys.exit(cli_main())

--- a/packages/mcp-server/tests/test_cli.py
+++ b/packages/mcp-server/tests/test_cli.py
@@ -1,0 +1,207 @@
+"""Tests for the CLI entry point."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from claude_session_coordinator.__main__ import (
+    create_parser,
+    validate_config,
+    cli_main,
+)
+
+
+class TestCLIParser:
+    """Tests for the argument parser."""
+
+    def test_parser_creation(self):
+        """Test that the parser is created correctly."""
+        parser = create_parser()
+        assert parser is not None
+        assert parser.prog == "claude-session-coordinator"
+
+    def test_parser_help(self):
+        """Test that --help works."""
+        parser = create_parser()
+        with pytest.raises(SystemExit) as exc_info:
+            parser.parse_args(["--help"])
+        assert exc_info.value.code == 0
+
+    def test_parser_version(self):
+        """Test that --version works."""
+        parser = create_parser()
+        with pytest.raises(SystemExit) as exc_info:
+            parser.parse_args(["--version"])
+        assert exc_info.value.code == 0
+
+    def test_parser_validate_config(self):
+        """Test that --validate-config flag is recognized."""
+        parser = create_parser()
+        args = parser.parse_args(["--validate-config"])
+        assert args.validate_config is True
+
+    def test_parser_verbose(self):
+        """Test that -v/--verbose flag is recognized."""
+        parser = create_parser()
+
+        # Test short form
+        args = parser.parse_args(["-v"])
+        assert args.verbose is True
+
+        # Test long form
+        args = parser.parse_args(["--verbose"])
+        assert args.verbose is True
+
+    def test_parser_defaults(self):
+        """Test default argument values."""
+        parser = create_parser()
+        args = parser.parse_args([])
+        assert args.validate_config is False
+        assert args.verbose is False
+
+
+class TestValidateConfig:
+    """Tests for configuration validation."""
+
+    def test_validate_config_with_defaults(self, monkeypatch):
+        """Test validating default configuration."""
+        # Mock load_config to return default config
+        from claude_session_coordinator.config import get_default_config
+
+        mock_config = get_default_config()
+        monkeypatch.setattr(
+            "claude_session_coordinator.__main__.load_config",
+            lambda: mock_config
+        )
+
+        # Should succeed with default config
+        result = validate_config()
+        assert result == 0
+
+    def test_validate_config_missing_storage(self, monkeypatch):
+        """Test validation fails with missing storage section."""
+        # Mock load_config to return invalid config
+        mock_config = {"session": {}}
+        monkeypatch.setattr(
+            "claude_session_coordinator.__main__.load_config",
+            lambda: mock_config
+        )
+
+        result = validate_config()
+        assert result == 1
+
+    def test_validate_config_missing_adapter(self, monkeypatch):
+        """Test validation fails with missing adapter specification."""
+        mock_config = {"storage": {}}
+        monkeypatch.setattr(
+            "claude_session_coordinator.__main__.load_config",
+            lambda: mock_config
+        )
+
+        result = validate_config()
+        assert result == 1
+
+    def test_validate_config_file_not_found(self, monkeypatch):
+        """Test validation handles missing config file gracefully."""
+        def raise_not_found():
+            raise FileNotFoundError("Config not found")
+
+        monkeypatch.setattr(
+            "claude_session_coordinator.__main__.load_config",
+            raise_not_found
+        )
+
+        # Should return 0 (uses defaults) when config file not found
+        result = validate_config()
+        assert result == 0
+
+    def test_validate_config_with_session_settings(self, monkeypatch):
+        """Test validation includes session configuration."""
+        from claude_session_coordinator.config import get_default_config
+
+        mock_config = get_default_config()
+        mock_config["session"] = {
+            "machine_id": "test-machine",
+            "project_detection": "directory"
+        }
+
+        monkeypatch.setattr(
+            "claude_session_coordinator.__main__.load_config",
+            lambda: mock_config
+        )
+
+        result = validate_config()
+        assert result == 0
+
+
+class TestCLIMain:
+    """Tests for the main CLI entry point."""
+
+    def test_cli_main_validate_config(self, monkeypatch):
+        """Test CLI with --validate-config argument."""
+        # Mock validate_config to return success
+        monkeypatch.setattr(
+            "claude_session_coordinator.__main__.validate_config",
+            lambda: 0
+        )
+
+        result = cli_main(["--validate-config"])
+        assert result == 0
+
+    def test_cli_main_version(self):
+        """Test CLI with --version argument."""
+        with pytest.raises(SystemExit) as exc_info:
+            cli_main(["--version"])
+        assert exc_info.value.code == 0
+
+    @patch("claude_session_coordinator.__main__.asyncio.run")
+    def test_cli_main_run_server(self, mock_asyncio_run):
+        """Test CLI runs server by default."""
+        mock_asyncio_run.return_value = None
+
+        result = cli_main([])
+
+        assert result == 0
+        mock_asyncio_run.assert_called_once()
+
+    @patch("claude_session_coordinator.__main__.asyncio.run")
+    def test_cli_main_verbose(self, mock_asyncio_run, capsys):
+        """Test CLI with verbose flag."""
+        mock_asyncio_run.return_value = None
+
+        result = cli_main(["--verbose"])
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "Starting Claude Session Coordinator" in captured.err
+
+    @patch("claude_session_coordinator.__main__.asyncio.run")
+    def test_cli_main_keyboard_interrupt(self, mock_asyncio_run, capsys):
+        """Test CLI handles KeyboardInterrupt gracefully."""
+        mock_asyncio_run.side_effect = KeyboardInterrupt()
+
+        result = cli_main([])
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "Shutting down" in captured.err
+
+    @patch("claude_session_coordinator.__main__.asyncio.run")
+    def test_cli_main_exception(self, mock_asyncio_run, capsys):
+        """Test CLI handles exceptions."""
+        mock_asyncio_run.side_effect = RuntimeError("Test error")
+
+        result = cli_main([])
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "Error:" in captured.err
+
+    @patch("claude_session_coordinator.__main__.asyncio.run")
+    def test_cli_main_exception_verbose(self, mock_asyncio_run, capsys):
+        """Test CLI shows traceback with verbose flag."""
+        mock_asyncio_run.side_effect = RuntimeError("Test error")
+
+        result = cli_main(["--verbose"])
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "Traceback" in captured.err or "RuntimeError" in captured.err


### PR DESCRIPTION
## Summary

Implements CLI argument parsing and utility commands for the MCP server entry point:

- **Argument parsing** using argparse with help text and usage examples
- **`--version`** flag to display version information
- **`--validate-config`** flag to validate configuration files and storage adapters
- **`--verbose`** flag for debugging with detailed error tracebacks
- **Comprehensive config validation** that checks required sections, validates adapters, and provides helpful error messages
- **Full test suite** (207 lines) covering all CLI functionality and edge cases

## Test plan

- [x] `python -m claude_session_coordinator` starts server
- [x] `python -m claude_session_coordinator --version` displays version
- [x] `python -m claude_session_coordinator --validate-config` validates configuration
- [x] `python -m claude_session_coordinator --verbose` enables verbose output
- [x] Graceful shutdown on SIGINT/SIGTERM
- [x] All tests pass (`pytest tests/test_cli.py`)

Resolves #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)