### PR TITLE
Fix MCP Server: Replace Server with FastMCP for decorator support

### DIFF
--- a/packages/mcp-server/src/claude_session_coordinator/server.py
+++ b/packages/mcp-server/src/claude_session_coordinator/server.py
@@ -6,8 +6,7 @@ and prompts for coordinating multiple Claude sessions across machines.
 
 import sys
 from typing import Optional, Dict, Any, List
-from mcp.server import Server
-from mcp.server.stdio import stdio_server
+from mcp.server.fastmcp import FastMCP
 
 from .adapters import StorageAdapter, AdapterFactory, StorageError
 from .config import load_config
@@ -15,7 +14,7 @@ from .detection import detect_machine_id, detect_project_id
 
 
 # Global server state
-app = Server("claude-session-coordinator")
+app = FastMCP("claude-session-coordinator")
 storage: Optional[StorageAdapter] = None
 machine_id: str = ""
 project_id: str = ""
@@ -496,13 +495,7 @@ Call `sign_off()` to release instance {current_session['session_id']}.
 async def main() -> None:
     """Main entry point for the MCP server."""
     initialize_server()
-
-    async with stdio_server() as (read_stream, write_stream):
-        await app.run(
-            read_stream,
-            write_stream,
-            app.create_initialization_options()
-        )
+    await app.run_stdio_async()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Fixed critical bug preventing MCP server from starting
- Replaced low-level `Server` class with `FastMCP` to enable decorator-based tool/resource/prompt registration
- Simplified server initialization

## Changes

**Before (Broken):**
```python
from mcp.server import Server
from mcp.server.stdio import stdio_server

app = Server("claude-session-coordinator")

@app.tool()  # ❌ AttributeError: 'Server' object has no attribute 'tool'
def sign_on(session_id: Optional[str] = None):
    ...
```

**After (Fixed):**
```python
from mcp.server.fastmcp import FastMCP

app = FastMCP("claude-session-coordinator")

@app.tool()  # ✅ Works correctly
def sign_on(session_id: str | None = None):
    ...
```

**File Modified:**
- `packages/mcp-server/src/claude_session_coordinator/server.py`
  - Changed import from `Server` to `FastMCP`
  - Removed unused `stdio_server` import
  - Updated `main()` function to use `app.run_stdio_async()`

## Test plan

- [x] All 106 tests pass
- [x] Module imports successfully
- [x] Server initialization works
- [x] 88% code coverage maintained

## Verification

```bash
cd packages/mcp-server
PYTHONPATH=src:$PYTHONPATH python -c "from claude_session_coordinator import server; print('✅ Import successful')"
PYTHONPATH=src:$PYTHONPATH pytest  # All 106 tests pass
```

## What was accomplished

✅ Fixed AttributeError that prevented server startup
✅ All decorator-based registrations (`@app.tool()`, `@app.resource()`, `@app.prompt()`) now work correctly
✅ Unblocks Phase 1.5 testing (Issue #7)
✅ Clean, surgical fix with minimal changes (3 insertions, 10 deletions)

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)