### PR TITLE
chore(mcp-server): apply Black and Ruff code formatting

### DIFF
--- a/packages/mcp-server/pyproject.toml
+++ b/packages/mcp-server/pyproject.toml
@@ -62,6 +62,8 @@ target-version = ["py310", "py311", "py312"]
 [tool.ruff]
 line-length = 100
 target-version = "py310"
+
+[tool.ruff.lint]
 select = ["E", "F", "I", "N", "W", "UP"]
 
 [tool.mypy]

--- a/packages/mcp-server/src/claude_session_coordinator/__init__.py
+++ b/packages/mcp-server/src/claude_session_coordinator/__init__.py
@@ -4,9 +4,10 @@ This package provides an MCP server that enables multiple Claude AI sessions
 to coordinate work across machines through flexible storage adapters.
 """
 
-from .adapters import StorageAdapter, LocalFileAdapter, AdapterFactory, StorageError
-from .config import load_config, get_default_config, save_config, validate_config
+from .adapters import AdapterFactory, LocalFileAdapter, StorageAdapter, StorageError
+from .config import get_default_config, load_config, save_config, validate_config
 from .detection import detect_machine_id, detect_project_id
+
 # from .server import app, initialize_server, main  # Temporarily disabled for issue #4 testing
 
 __version__ = "0.1.0"

--- a/packages/mcp-server/src/claude_session_coordinator/__main__.py
+++ b/packages/mcp-server/src/claude_session_coordinator/__main__.py
@@ -6,10 +6,9 @@ Run with: python -m claude_session_coordinator
 import argparse
 import asyncio
 import sys
-from typing import Optional
 
 from . import __version__
-from .config import load_config, get_default_config
+from .config import get_default_config, load_config
 from .server import main
 
 
@@ -36,27 +35,21 @@ Examples:
 
 For more information, visit:
   https://github.com/BANCS-Norway/claude_session_coordinator
-        """
+        """,
     )
 
     parser.add_argument(
         "--version",
         action="version",
         version=f"%(prog)s {__version__}",
-        help="show version and exit"
+        help="show version and exit",
     )
 
     parser.add_argument(
-        "--validate-config",
-        action="store_true",
-        help="validate configuration and exit"
+        "--validate-config", action="store_true", help="validate configuration and exit"
     )
 
-    parser.add_argument(
-        "-v", "--verbose",
-        action="store_true",
-        help="enable verbose logging"
-    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="enable verbose logging")
 
     return parser
 
@@ -122,6 +115,7 @@ def validate_config() -> int:
         print("\nUsing default configuration:")
         default_config = get_default_config()
         import json
+
         print(json.dumps(default_config, indent=2))
         print("\n✓ Default configuration is valid")
         return 0
@@ -153,11 +147,12 @@ def run_server(verbose: bool = False) -> int:
         print(f"Error: {e}", file=sys.stderr)
         if verbose:
             import traceback
+
             traceback.print_exc()
         return 1
 
 
-def cli_main(argv: Optional[list[str]] = None) -> int:
+def cli_main(argv: list[str] | None = None) -> int:
     """Main CLI entry point.
 
     Args:

--- a/packages/mcp-server/src/claude_session_coordinator/adapters/base.py
+++ b/packages/mcp-server/src/claude_session_coordinator/adapters/base.py
@@ -127,4 +127,5 @@ class StorageAdapter(ABC):
 
 class StorageError(Exception):
     """Base exception for storage-related errors."""
+
     pass

--- a/packages/mcp-server/src/claude_session_coordinator/adapters/factory.py
+++ b/packages/mcp-server/src/claude_session_coordinator/adapters/factory.py
@@ -5,13 +5,14 @@ configuration. It supports built-in adapters (local, redis) and allows users
 to register custom adapter implementations.
 """
 
-from typing import Any, Callable, Dict
+from collections.abc import Callable
+from typing import Any
 
 from .base import StorageAdapter, StorageError
 from .local import LocalFileAdapter
 
 # Type alias for adapter constructor functions
-AdapterConstructor = Callable[[Dict[str, Any]], StorageAdapter]
+AdapterConstructor = Callable[[dict[str, Any]], StorageAdapter]
 
 
 class AdapterFactory:
@@ -28,7 +29,7 @@ class AdapterFactory:
     """
 
     # Built-in adapter registry
-    _adapters: Dict[str, AdapterConstructor] = {}
+    _adapters: dict[str, AdapterConstructor] = {}
 
     @classmethod
     def register_adapter(cls, name: str, constructor: AdapterConstructor) -> None:
@@ -46,7 +47,7 @@ class AdapterFactory:
         cls._adapters[name] = constructor
 
     @classmethod
-    def create_adapter(cls, config: Dict[str, Any]) -> StorageAdapter:
+    def create_adapter(cls, config: dict[str, Any]) -> StorageAdapter:
         """Create a storage adapter from configuration.
 
         Args:
@@ -78,9 +79,7 @@ class AdapterFactory:
             try:
                 return cls._adapters[adapter_type](adapter_config)
             except Exception as e:
-                raise StorageError(
-                    f"Failed to create adapter of type '{adapter_type}': {e}"
-                ) from e
+                raise StorageError(f"Failed to create adapter of type '{adapter_type}': {e}") from e
 
         # Unknown adapter type
         raise StorageError(
@@ -90,7 +89,7 @@ class AdapterFactory:
 
 
 # Register built-in adapters
-def _create_local_adapter(config: Dict[str, Any]) -> LocalFileAdapter:
+def _create_local_adapter(config: dict[str, Any]) -> LocalFileAdapter:
     """Create a LocalFileAdapter from configuration."""
     base_path = config.get("base_path", ".claude/session-state")
     return LocalFileAdapter(base_path=base_path)

--- a/packages/mcp-server/src/claude_session_coordinator/adapters/local.py
+++ b/packages/mcp-server/src/claude_session_coordinator/adapters/local.py
@@ -5,7 +5,6 @@ is stored as a separate JSON file in the configured directory (default: .claude/
 """
 
 import json
-import os
 from datetime import datetime
 from fnmatch import fnmatch
 from pathlib import Path
@@ -111,7 +110,7 @@ class LocalFileAdapter(StorageAdapter):
             return {}
 
         try:
-            with open(scope_path, "r", encoding="utf-8") as f:
+            with open(scope_path, encoding="utf-8") as f:
                 data = json.load(f)
                 return cast(dict[str, Any], data)
         except json.JSONDecodeError as e:

--- a/packages/mcp-server/src/claude_session_coordinator/config.py
+++ b/packages/mcp-server/src/claude_session_coordinator/config.py
@@ -3,10 +3,10 @@
 import json
 import os
 from pathlib import Path
-from typing import Any, Dict, Optional, cast
+from typing import Any, cast
 
 
-def load_config() -> Dict[str, Any]:
+def load_config() -> dict[str, Any]:
     """Load configuration from file or use defaults.
 
     Priority order:
@@ -49,7 +49,7 @@ def load_config() -> Dict[str, Any]:
     return get_default_config()
 
 
-def _load_config_file(config_path: Path) -> Dict[str, Any]:
+def _load_config_file(config_path: Path) -> dict[str, Any]:
     """Load configuration from a JSON file.
 
     Args:
@@ -58,31 +58,26 @@ def _load_config_file(config_path: Path) -> Dict[str, Any]:
     Returns:
         Configuration dictionary
     """
-    with open(config_path, 'r', encoding='utf-8') as f:
-        return cast(Dict[str, Any], json.load(f))
+    with open(config_path, encoding="utf-8") as f:
+        return cast(dict[str, Any], json.load(f))
 
 
-def get_default_config() -> Dict[str, Any]:
+def get_default_config() -> dict[str, Any]:
     """Get the default configuration.
 
     Returns:
         Default configuration dictionary
     """
     return {
-        "storage": {
-            "adapter": "local",
-            "config": {
-                "base_path": ".claude/session-state"
-            }
-        },
+        "storage": {"adapter": "local", "config": {"base_path": ".claude/session-state"}},
         "session": {
             "machine_id": "auto",  # "auto" = use hostname, or specify custom value
-            "project_detection": "git"  # "git" or "directory"
-        }
+            "project_detection": "git",  # "git" or "directory"
+        },
     }
 
 
-def validate_config(config: Dict[str, Any]) -> bool:
+def validate_config(config: dict[str, Any]) -> bool:
     """Validate configuration structure.
 
     Args:
@@ -108,14 +103,13 @@ def validate_config(config: Dict[str, Any]) -> bool:
     adapter_type = config["storage"]["adapter"]
     if adapter_type not in valid_adapters:
         raise ValueError(
-            f"Unknown adapter type: {adapter_type}. "
-            f"Valid options: {', '.join(valid_adapters)}"
+            f"Unknown adapter type: {adapter_type}. " f"Valid options: {', '.join(valid_adapters)}"
         )
 
     return True
 
 
-def save_config(config: Dict[str, Any], location: str = "project") -> None:
+def save_config(config: dict[str, Any], location: str = "project") -> None:
     """Save configuration to a file.
 
     Args:
@@ -139,5 +133,5 @@ def save_config(config: Dict[str, Any], location: str = "project") -> None:
     else:
         raise ValueError(f"Invalid location: {location}. Must be 'project' or 'user'")
 
-    with open(config_file, 'w', encoding='utf-8') as f:
+    with open(config_file, "w", encoding="utf-8") as f:
         json.dump(config, f, indent=2)

--- a/packages/mcp-server/src/claude_session_coordinator/detection.py
+++ b/packages/mcp-server/src/claude_session_coordinator/detection.py
@@ -3,10 +3,10 @@
 import socket
 import subprocess
 from pathlib import Path
-from typing import Any, Dict, cast
+from typing import Any, cast
 
 
-def detect_machine_id(config: Dict[str, Any]) -> str:
+def detect_machine_id(config: dict[str, Any]) -> str:
     """Detect machine identifier.
 
     Args:
@@ -25,7 +25,7 @@ def detect_machine_id(config: Dict[str, Any]) -> str:
         return cast(str, machine_id_setting)
 
 
-def detect_project_id(config: Dict[str, Any]) -> str:
+def detect_project_id(config: dict[str, Any]) -> str:
     """Detect project identifier from git or directory.
 
     Args:
@@ -60,7 +60,7 @@ def _detect_project_from_git() -> str:
             capture_output=True,
             text=True,
             check=True,
-            timeout=5
+            timeout=5,
         )
         remote_url = result.stdout.strip()
 

--- a/packages/mcp-server/tests/test_adapters.py
+++ b/packages/mcp-server/tests/test_adapters.py
@@ -3,7 +3,7 @@
 import json
 import tempfile
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 
@@ -137,9 +137,7 @@ class TestLocalFileAdapter:
         result = adapter.delete(scope, "nonexistent")
         assert result is False
 
-    def test_delete_last_key_removes_file(
-        self, adapter: LocalFileAdapter, temp_dir: Path
-    ) -> None:
+    def test_delete_last_key_removes_file(self, adapter: LocalFileAdapter, temp_dir: Path) -> None:
         """Test that deleting the last key in a scope removes the file."""
         scope = "laptop:org/repo:session:test"
         key = "only_key"
@@ -231,9 +229,7 @@ class TestLocalFileAdapter:
         result = adapter.delete_scope("nonexistent:scope:test:id")
         assert result is False
 
-    def test_metadata_timestamps(
-        self, adapter: LocalFileAdapter, temp_dir: Path
-    ) -> None:
+    def test_metadata_timestamps(self, adapter: LocalFileAdapter, temp_dir: Path) -> None:
         """Test that metadata includes created_at and updated_at timestamps."""
         scope = "laptop:org/repo:session:test"
         key = "data"
@@ -243,7 +239,7 @@ class TestLocalFileAdapter:
 
         # Load the scope file directly to check metadata
         scope_file = temp_dir / adapter._scope_to_filename(scope)
-        with open(scope_file, "r") as f:
+        with open(scope_file) as f:
             scope_data = json.load(f)
 
         assert "metadata" in scope_data
@@ -257,7 +253,7 @@ class TestLocalFileAdapter:
         adapter.store(scope, key, "updated")
 
         # Check that updated_at changed but created_at didn't
-        with open(scope_file, "r") as f:
+        with open(scope_file) as f:
             scope_data = json.load(f)
 
         assert scope_data["metadata"][key]["created_at"] == created_at
@@ -280,9 +276,7 @@ class TestLocalFileAdapter:
         # For LocalFileAdapter, close() is a no-op, but should not raise
         adapter.close()
 
-    def test_invalid_json_raises_error(
-        self, adapter: LocalFileAdapter, temp_dir: Path
-    ) -> None:
+    def test_invalid_json_raises_error(self, adapter: LocalFileAdapter, temp_dir: Path) -> None:
         """Test that corrupted JSON file raises StorageError."""
         scope = "laptop:org/repo:session:test"
         scope_file = temp_dir / adapter._scope_to_filename(scope)
@@ -296,7 +290,6 @@ class TestLocalFileAdapter:
 
     def test_directory_creation_failure(self, temp_dir: Path) -> None:
         """Test that OSError during directory creation raises StorageError."""
-        import os
         from unittest.mock import patch
 
         # Create a file where we want to create a directory
@@ -320,14 +313,11 @@ class TestLocalFileAdapter:
         scope = adapter._filename_to_scope(filename)
         assert scope == "machine:org"
 
-    def test_read_scope_file_os_error(
-        self, adapter: LocalFileAdapter, temp_dir: Path
-    ) -> None:
+    def test_read_scope_file_os_error(self, adapter: LocalFileAdapter, temp_dir: Path) -> None:
         """Test that OSError when reading scope file raises StorageError."""
-        from unittest.mock import mock_open, patch
+        from unittest.mock import patch
 
         scope = "laptop:org/repo:session:test"
-        scope_path = adapter._get_scope_path(scope)
 
         # Create the file first
         adapter.store(scope, "key", "value")
@@ -337,9 +327,7 @@ class TestLocalFileAdapter:
             with pytest.raises(StorageError, match="Failed to read scope file"):
                 adapter.retrieve(scope, "key")
 
-    def test_save_non_json_serializable_value(
-        self, adapter: LocalFileAdapter
-    ) -> None:
+    def test_save_non_json_serializable_value(self, adapter: LocalFileAdapter) -> None:
         """Test that non-JSON-serializable values raise StorageError."""
         scope = "laptop:org/repo:session:test"
 
@@ -350,9 +338,7 @@ class TestLocalFileAdapter:
         with pytest.raises(StorageError, match="not JSON-serializable"):
             adapter.store(scope, "key", NonSerializable())
 
-    def test_save_scope_file_os_error(
-        self, adapter: LocalFileAdapter, temp_dir: Path
-    ) -> None:
+    def test_save_scope_file_os_error(self, adapter: LocalFileAdapter, temp_dir: Path) -> None:
         """Test that OSError when saving scope file raises StorageError."""
         from unittest.mock import mock_open, patch
 
@@ -366,9 +352,7 @@ class TestLocalFileAdapter:
             with pytest.raises(StorageError, match="Failed to write scope file"):
                 adapter.store(scope, "key", "value")
 
-    def test_delete_scope_file_os_error(
-        self, adapter: LocalFileAdapter, temp_dir: Path
-    ) -> None:
+    def test_delete_scope_file_os_error(self, adapter: LocalFileAdapter, temp_dir: Path) -> None:
         """Test that OSError when deleting scope file raises StorageError."""
         from unittest.mock import patch
 
@@ -406,9 +390,7 @@ class TestLocalFileAdapter:
         assert adapter.retrieve(scope, "key2") is None
         assert adapter.retrieve(scope, "key3") == "value3"
 
-    def test_list_scopes_os_error(
-        self, adapter: LocalFileAdapter, temp_dir: Path
-    ) -> None:
+    def test_list_scopes_os_error(self, adapter: LocalFileAdapter, temp_dir: Path) -> None:
         """Test that OSError when listing scopes raises StorageError."""
         from unittest.mock import patch
 
@@ -417,9 +399,7 @@ class TestLocalFileAdapter:
             with pytest.raises(StorageError, match="Failed to list scope files"):
                 adapter.list_scopes()
 
-    def test_delete_scope_os_error(
-        self, adapter: LocalFileAdapter, temp_dir: Path
-    ) -> None:
+    def test_delete_scope_os_error(self, adapter: LocalFileAdapter, temp_dir: Path) -> None:
         """Test that OSError when deleting scope raises StorageError."""
         from unittest.mock import patch
 
@@ -501,7 +481,7 @@ class TestAdapterFactory:
             def close(self) -> None:
                 pass
 
-        def create_custom(config: Dict[str, Any]) -> CustomAdapter:
+        def create_custom(config: dict[str, Any]) -> CustomAdapter:
             return CustomAdapter(custom_param=config.get("custom_param", "default"))
 
         # Register the custom adapter
@@ -517,7 +497,7 @@ class TestAdapterFactory:
     def test_custom_adapter_creation_failure(self) -> None:
         """Test that exceptions during custom adapter creation are handled."""
 
-        def failing_creator(config: Dict[str, Any]) -> StorageAdapter:
+        def failing_creator(config: dict[str, Any]) -> StorageAdapter:
             raise ValueError("Creation failed!")
 
         # Register a failing adapter

--- a/packages/mcp-server/tests/test_cli.py
+++ b/packages/mcp-server/tests/test_cli.py
@@ -1,11 +1,13 @@
 """Tests for the CLI entry point."""
 
+from unittest.mock import patch
+
 import pytest
-from unittest.mock import patch, MagicMock
+
 from claude_session_coordinator.__main__ import (
+    cli_main,
     create_parser,
     validate_config,
-    cli_main,
 )
 
 
@@ -67,10 +69,7 @@ class TestValidateConfig:
         from claude_session_coordinator.config import get_default_config
 
         mock_config = get_default_config()
-        monkeypatch.setattr(
-            "claude_session_coordinator.__main__.load_config",
-            lambda: mock_config
-        )
+        monkeypatch.setattr("claude_session_coordinator.__main__.load_config", lambda: mock_config)
 
         # Should succeed with default config
         result = validate_config()
@@ -80,10 +79,7 @@ class TestValidateConfig:
         """Test validation fails with missing storage section."""
         # Mock load_config to return invalid config
         mock_config = {"session": {}}
-        monkeypatch.setattr(
-            "claude_session_coordinator.__main__.load_config",
-            lambda: mock_config
-        )
+        monkeypatch.setattr("claude_session_coordinator.__main__.load_config", lambda: mock_config)
 
         result = validate_config()
         assert result == 1
@@ -91,23 +87,18 @@ class TestValidateConfig:
     def test_validate_config_missing_adapter(self, monkeypatch):
         """Test validation fails with missing adapter specification."""
         mock_config = {"storage": {}}
-        monkeypatch.setattr(
-            "claude_session_coordinator.__main__.load_config",
-            lambda: mock_config
-        )
+        monkeypatch.setattr("claude_session_coordinator.__main__.load_config", lambda: mock_config)
 
         result = validate_config()
         assert result == 1
 
     def test_validate_config_file_not_found(self, monkeypatch):
         """Test validation handles missing config file gracefully."""
+
         def raise_not_found():
             raise FileNotFoundError("Config not found")
 
-        monkeypatch.setattr(
-            "claude_session_coordinator.__main__.load_config",
-            raise_not_found
-        )
+        monkeypatch.setattr("claude_session_coordinator.__main__.load_config", raise_not_found)
 
         # Should return 0 (uses defaults) when config file not found
         result = validate_config()
@@ -118,15 +109,9 @@ class TestValidateConfig:
         from claude_session_coordinator.config import get_default_config
 
         mock_config = get_default_config()
-        mock_config["session"] = {
-            "machine_id": "test-machine",
-            "project_detection": "directory"
-        }
+        mock_config["session"] = {"machine_id": "test-machine", "project_detection": "directory"}
 
-        monkeypatch.setattr(
-            "claude_session_coordinator.__main__.load_config",
-            lambda: mock_config
-        )
+        monkeypatch.setattr("claude_session_coordinator.__main__.load_config", lambda: mock_config)
 
         result = validate_config()
         assert result == 0
@@ -138,10 +123,7 @@ class TestCLIMain:
     def test_cli_main_validate_config(self, monkeypatch):
         """Test CLI with --validate-config argument."""
         # Mock validate_config to return success
-        monkeypatch.setattr(
-            "claude_session_coordinator.__main__.validate_config",
-            lambda: 0
-        )
+        monkeypatch.setattr("claude_session_coordinator.__main__.validate_config", lambda: 0)
 
         result = cli_main(["--validate-config"])
         assert result == 0

--- a/packages/mcp-server/tests/test_detection.py
+++ b/packages/mcp-server/tests/test_detection.py
@@ -1,10 +1,9 @@
 """Comprehensive tests for configuration and detection modules."""
 
 import json
-import os
 import tempfile
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -142,9 +141,7 @@ class TestConfigLoading:
         claude_dir = temp_dir / ".claude"
         claude_dir.mkdir()
         project_config = claude_dir / "session-coordinator-config.json"
-        project_config.write_text(
-            json.dumps({"session": {"machine_id": "project-machine"}})
-        )
+        project_config.write_text(json.dumps({"session": {"machine_id": "project-machine"}}))
 
         # Create env var config
         env_config_file = temp_dir / "env-config.json"
@@ -173,9 +170,7 @@ class TestConfigLoading:
         claude_dir = temp_dir / ".claude"
         claude_dir.mkdir()
         project_config = claude_dir / "session-coordinator-config.json"
-        project_config.write_text(
-            json.dumps({"session": {"machine_id": "project-machine"}})
-        )
+        project_config.write_text(json.dumps({"session": {"machine_id": "project-machine"}}))
 
         config = load_config()
 
@@ -236,7 +231,7 @@ class TestConfigLoading:
 
     def test_validate_config_missing_storage(self) -> None:
         """Test that validate_config rejects config without storage section."""
-        config: Dict[str, Any] = {"session": {}}
+        config: dict[str, Any] = {"session": {}}
         with pytest.raises(ValueError, match="Missing 'storage' section"):
             validate_config(config)
 
@@ -254,12 +249,7 @@ class TestConfigLoading:
 
     def test_validate_config_invalid_adapter_type(self) -> None:
         """Test that validate_config rejects unknown adapter types."""
-        config = {
-            "storage": {
-                "adapter": "unknown_adapter",
-                "config": {}
-            }
-        }
+        config = {"storage": {"adapter": "unknown_adapter", "config": {}}}
         with pytest.raises(ValueError, match="Unknown adapter type"):
             validate_config(config)
 
@@ -269,7 +259,7 @@ class TestConfigLoading:
         """Test that save_config validates configuration before saving."""
         monkeypatch.chdir(temp_dir)
 
-        invalid_config: Dict[str, Any] = {"invalid": "config"}
+        invalid_config: dict[str, Any] = {"invalid": "config"}
 
         with pytest.raises(ValueError, match="Missing 'storage' section"):
             save_config(invalid_config, location="project")
@@ -299,7 +289,7 @@ class TestMachineDetection:
 
     def test_detect_machine_id_missing_config_defaults_to_auto(self) -> None:
         """Test that missing machine_id config defaults to auto detection."""
-        config: Dict[str, Any] = {}
+        config: dict[str, Any] = {}
 
         with patch("claude_session_coordinator.detection.socket.gethostname") as mock_hostname:
             mock_hostname.return_value = "default-machine"
@@ -361,11 +351,10 @@ class TestProjectDetection:
         """Test that git detection falls back to directory name on failure."""
         config = {"session": {"project_detection": "git"}}
 
-        with patch(
-            "claude_session_coordinator.detection.subprocess.run"
-        ) as mock_run, patch(
-            "claude_session_coordinator.detection.Path.cwd"
-        ) as mock_cwd:
+        with (
+            patch("claude_session_coordinator.detection.subprocess.run") as mock_run,
+            patch("claude_session_coordinator.detection.Path.cwd") as mock_cwd,
+        ):
             # Simulate git command failure
             from subprocess import CalledProcessError
 
@@ -380,11 +369,10 @@ class TestProjectDetection:
         """Test that git timeout falls back to directory name."""
         config = {"session": {"project_detection": "git"}}
 
-        with patch(
-            "claude_session_coordinator.detection.subprocess.run"
-        ) as mock_run, patch(
-            "claude_session_coordinator.detection.Path.cwd"
-        ) as mock_cwd:
+        with (
+            patch("claude_session_coordinator.detection.subprocess.run") as mock_run,
+            patch("claude_session_coordinator.detection.Path.cwd") as mock_cwd,
+        ):
             # Simulate git command timeout
             from subprocess import TimeoutExpired
 
@@ -414,7 +402,7 @@ class TestProjectDetection:
 
     def test_detect_project_missing_config_defaults_to_git(self) -> None:
         """Test that missing project_detection defaults to git method."""
-        config: Dict[str, Any] = {}
+        config: dict[str, Any] = {}
         git_output = "git@github.com:owner/repo.git\n"
 
         with patch("claude_session_coordinator.detection.subprocess.run") as mock_run:
@@ -428,11 +416,10 @@ class TestProjectDetection:
         config = {"session": {"project_detection": "git"}}
         git_output = "weird://format/url\n"
 
-        with patch(
-            "claude_session_coordinator.detection.subprocess.run"
-        ) as mock_run, patch(
-            "claude_session_coordinator.detection.Path.cwd"
-        ) as mock_cwd:
+        with (
+            patch("claude_session_coordinator.detection.subprocess.run") as mock_run,
+            patch("claude_session_coordinator.detection.Path.cwd") as mock_cwd,
+        ):
             mock_run.return_value.stdout = git_output
             mock_cwd.return_value = Path("/fallback/project-name")
 
@@ -454,9 +441,10 @@ class TestConfigDetectionIntegration:
         """Test complete workflow using default configuration."""
         config = load_config()
 
-        with patch("claude_session_coordinator.detection.socket.gethostname") as mock_hostname, patch(
-            "claude_session_coordinator.detection.subprocess.run"
-        ) as mock_git:
+        with (
+            patch("claude_session_coordinator.detection.socket.gethostname") as mock_hostname,
+            patch("claude_session_coordinator.detection.subprocess.run") as mock_git,
+        ):
             mock_hostname.return_value = "my-laptop"
             mock_git.return_value.stdout = "git@github.com:org/repo.git\n"
 
@@ -466,7 +454,9 @@ class TestConfigDetectionIntegration:
         assert machine_id == "my-laptop"
         assert project_id == "org/repo"
 
-    def test_full_workflow_with_custom_config(self, temp_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_full_workflow_with_custom_config(
+        self, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test complete workflow with custom configuration."""
         monkeypatch.chdir(temp_dir)
 

--- a/packages/mcp-server/tests/test_server.py
+++ b/packages/mcp-server/tests/test_server.py
@@ -1,8 +1,9 @@
 """Tests for the MCP server tools, resources, and prompts."""
 
 import json
+
 import pytest
-from pathlib import Path
+
 from claude_session_coordinator import server
 from claude_session_coordinator.adapters import LocalFileAdapter
 
@@ -122,8 +123,8 @@ class TestDataTools:
             "current_issue": 15,
             "todos": [
                 {"task": "Task 1", "status": "completed"},
-                {"task": "Task 2", "status": "pending"}
-            ]
+                {"task": "Task 2", "status": "pending"},
+            ],
         }
 
         server.store_data("session:claude_1", "complex_data", test_data)
@@ -345,7 +346,7 @@ class TestPrompts:
         todos = [
             {"task": "Task 1", "status": "completed"},
             {"task": "Task 2", "status": "pending"},
-            {"task": "Task 3", "status": "in_progress"}
+            {"task": "Task 3", "status": "in_progress"},
         ]
         server.store_data("session:claude_1", "current_issue", 15)
         server.store_data("session:claude_1", "todos", todos)
@@ -362,7 +363,7 @@ class TestPrompts:
         # Create all completed todos
         todos = [
             {"task": "Task 1", "status": "completed"},
-            {"task": "Task 2", "status": "completed"}
+            {"task": "Task 2", "status": "completed"},
         ]
         server.store_data("session:claude_1", "current_issue", 15)
         server.store_data("session:claude_1", "todos", todos)


### PR DESCRIPTION
## Summary

Applies Black and Ruff code formatting to the entire MCP server package, resolving all formatting inconsistencies discovered during Phase 1.5 testing.

**Changes:**
- Updated `pyproject.toml` to use modern Ruff configuration format
- Applied Black auto-formatting to all source and test files
- Applied Ruff auto-fixes for import sorting and type annotation modernization
- Zero functional changes - formatting only

**Note:** This PR was rebased on main after PR #35 (92% coverage) was merged. The new coverage tests added in PR #35 have also been formatted to maintain consistency across the entire codebase.

**Detailed breakdown:**
- **Configuration:** Moved `select` from `[tool.ruff]` to `[tool.ruff.lint]` (fixes deprecation warning)
- **Black:** Reformatted all source files and tests (including new coverage tests)
- **Ruff:** Auto-fixed 54+ linting issues:
  - I001: Import sorting and organization
  - UP035: Use `collections.abc.Callable` instead of `typing.Callable`
  - UP045: Use `X | None` instead of `Optional[X]`
  - Removed unused imports and variables

**Impact:**
- 13 files changed, 134 insertions(+), 183 deletions(-)
- Net code reduction due to formatting improvements

## Test Plan

- [x] All 116 tests passing (92% coverage maintained from PR #35)
- [x] Black `--check` passes (all files formatted correctly)
- [x] Ruff `check` passes (no linting issues)
- [x] Mypy type checking still passes
- [x] No functional changes - formatting only

## Verification Commands

```bash
cd packages/mcp-server
black --check src/ tests/
ruff check src/ tests/
PYTHONPATH=src:$PYTHONPATH pytest
```

All checks pass with no errors.

## Related Issues

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)