### PR TITLE
fix(repo): align lefthook ruff configuration with CI behavior

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,8 +11,9 @@ pre-commit:
 
     # Ruff - Fast Python linter
     ruff:
-      glob: "packages/mcp-server/**/*.py"
-      run: ruff check --config packages/mcp-server/pyproject.toml {staged_files}
+      root: "packages/mcp-server/"
+      glob: "**/*.py"
+      run: ruff check src/ tests/
 
     # Mypy - Static type checker
     mypy:


### PR DESCRIPTION
## Summary
- Aligned lefthook ruff configuration to match CI workflow behavior
- Prevents commits that pass locally but fail in CI lint checks

## Changes
- Updated `lefthook.yml` to use `root:` directive for ruff hook
- Changed ruff to run from `packages/mcp-server/` directory (matching CI)
- Removed `--config` flag that caused different import sorting behavior
- Ruff now automatically discovers `pyproject.toml` in current directory

## Technical Details

**Before:**
```yaml
ruff:
  glob: "packages/mcp-server/**/*.py"
  run: ruff check --config packages/mcp-server/pyproject.toml {staged_files}
```
- Ran from repository root with explicit config path
- Only checked staged files
- Different import sorting behavior than CI

**After:**
```yaml
ruff:
  root: "packages/mcp-server/"
  glob: "**/*.py"
  run: ruff check src/ tests/
```
- Runs from `packages/mcp-server/` directory (matches CI exactly)
- Checks all files in src/ and tests/ (matches CI)
- Identical import sorting behavior to CI

## Test plan
- [x] Verified solution works in git worktree scenario
- [x] Verified solution works in main repo scenario
- [x] Confirmed lefthook and CI produce identical results
- [x] Configuration change is minimal and focused

## What was accomplished
- Resolved mismatch between local pre-commit hooks and CI checks
- Ensured consistent linting behavior across all development workflows
- Works correctly for both git worktree and traditional workflows
- Eliminates developer confusion from passing local checks but failing CI

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)