### PR TITLE
feat(repo): implement monorepo-wide lint command for all packages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -375,9 +375,32 @@ If any check fails, the commit is blocked until you fix the issues.
 
 #### Running Linters Manually
 
+**Monorepo-wide linting:**
+
 ```bash
-# Check formatting with Black
+# Lint all packages in the monorepo
+npm run lint
+
+# Auto-fix issues in all packages
+npm run lint:fix
+```
+
+**Package-specific linting:**
+
+```bash
+# Lint a specific package
+npm run lint --workspace=packages/mcp-server
+
+# Auto-fix issues in a specific package
+npm run lint:fix --workspace=packages/mcp-server
+```
+
+**Direct Python tool usage (mcp-server package):**
+
+```bash
 cd packages/mcp-server
+
+# Check formatting with Black
 black --check src/ tests/
 
 # Auto-format with Black

--- a/package.json
+++ b/package.json
@@ -3,8 +3,13 @@
   "version": "0.1.0",
   "description": "MCP server for coordinating multiple Claude AI sessions",
   "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
-    "postinstall": "lefthook install"
+    "postinstall": "lefthook install",
+    "lint": "npm run lint --workspaces --if-present",
+    "lint:fix": "npm run lint:fix --workspaces --if-present"
   },
   "repository": {
     "type": "git",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@claude-session-coordinator/mcp-server",
+  "version": "0.1.0",
+  "description": "Python MCP server for coordinating multiple Claude AI sessions",
+  "scripts": {
+    "lint": "npm run lint:black && npm run lint:ruff && npm run lint:mypy",
+    "lint:black": "black --check --config pyproject.toml .",
+    "lint:ruff": "ruff check --config pyproject.toml .",
+    "lint:mypy": "mypy --config-file pyproject.toml src/",
+    "lint:fix": "black --config pyproject.toml . && ruff check --fix --config pyproject.toml ."
+  }
+}


### PR DESCRIPTION
## Summary

Implements a monorepo-wide lint command infrastructure using npm workspaces that scales automatically as new packages are added.

## Changes

- **Root package.json:**
  - Added `"workspaces": ["packages/*"]` configuration
  - Added `npm run lint` - Lint all packages in the monorepo
  - Added `npm run lint:fix` - Auto-fix issues in all packages
  - Uses `--workspaces --if-present` for language-agnostic orchestration

- **packages/mcp-server/package.json (new file):**
  - Created package-specific lint scripts for Python
  - `npm run lint` - Runs Black, Ruff, and Mypy
  - `npm run lint:fix` - Auto-fixes Black and Ruff issues
  - Package owns its linting needs (monorepo-first design)

- **CONTRIBUTING.md:**
  - Added monorepo-wide linting documentation
  - Documented package-specific linting commands
  - Added direct Python tool usage examples

## Test plan

- [x] `npm run lint` successfully lints all packages
- [x] `npm run lint:fix` successfully auto-fixes issues
- [x] Package-specific linting works: `npm run lint --workspace=packages/mcp-server`
- [x] All Python linters pass (Black, Ruff, Mypy)
- [x] Ready for future packages (homepage, vscode-plugin, etc.)

## What was accomplished

✅ Language-agnostic linting infrastructure - Root doesn't know about Python, TypeScript, etc.  
✅ Scalable design - Adding new packages requires no changes to root package.json  
✅ Consistent developer experience - Same `npm run lint` command works for all packages  
✅ Future-proof - Ready for TypeScript packages (homepage, vscode-plugin)  
✅ Documentation updated with clear examples

**Note:** CI/CD workflows intentionally not updated per discussion. Package-specific CI workflows remain for efficiency (path-based triggering).

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)