### PR TITLE
fix(repo): patch lefthook hooks to work with git worktrees

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "packages/*"
   ],
   "scripts": {
-    "postinstall": "lefthook install",
+    "postinstall": "lefthook install && bash scripts/fix-lefthook-worktree.sh",
     "lint": "npm run lint --workspaces --if-present",
     "lint:fix": "npm run lint:fix --workspaces --if-present"
   },

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,41 @@
+# Repository Scripts
+
+This directory contains utility scripts for the claude_session_coordinator repository.
+
+## fix-lefthook-worktree.sh
+
+Patches lefthook git hooks to work correctly with git worktrees.
+
+### Problem
+
+Lefthook's auto-generated hooks use `git rev-parse --show-toplevel` to find the repository root, which returns the worktree directory when running from a git worktree instead of the main repository root. This causes hooks to fail with "Can't find lefthook in PATH" errors.
+
+### Solution
+
+This script patches the hooks to use:
+```bash
+git_common_dir="$(git rev-parse --git-common-dir)"
+dir="$(cd "$git_common_dir/.." && pwd)"
+```
+
+This approach correctly finds the repository root whether running from the main worktree or a git worktree.
+
+### Usage
+
+The script is automatically run as part of `npm install` via the postinstall hook in package.json.
+
+Manual execution:
+```bash
+bash scripts/fix-lefthook-worktree.sh
+```
+
+### When to Run
+
+- Automatically after `npm install` (via postinstall hook)
+- After manually running `lefthook install`
+- If you encounter "Can't find lefthook in PATH" errors from git worktrees
+
+### Related
+
+- Issue #47: Lefthook hooks fail to find executable when running from git worktrees
+- Issue #37: Setup Automatic Linting Enforcement (introduced lefthook)

--- a/scripts/fix-lefthook-worktree.sh
+++ b/scripts/fix-lefthook-worktree.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Fix Lefthook hooks to work with git worktrees
+#
+# This script patches the auto-generated lefthook hooks to correctly find
+# the repository root when running from git worktrees.
+#
+# Issue: https://github.com/BANCS-Norway/claude_session_coordinator/issues/47
+
+set -e
+
+# Find the repository root (works from both main worktree and git worktrees)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+GIT_COMMON_DIR="$(git rev-parse --git-common-dir)"
+REPO_ROOT="$(cd "$GIT_COMMON_DIR/.." && pwd)"
+HOOKS_DIR="$REPO_ROOT/.git/hooks"
+
+echo "Fixing lefthook hooks for git worktree compatibility..."
+
+# Fix pre-commit hook
+if [ -f "$HOOKS_DIR/pre-commit" ]; then
+    echo "  Patching pre-commit hook..."
+
+    # Replace the problematic line:
+    #   dir="$(git rev-parse --show-toplevel)"
+    # With:
+    #   git_common_dir="$(git rev-parse --git-common-dir)"
+    #   dir="$(cd "$git_common_dir/.." && pwd)"
+
+    sed -i.bak '
+        /dir="\$(git rev-parse --show-toplevel)"/c\
+    git_common_dir="$(git rev-parse --git-common-dir)"\
+    dir="$(cd "$git_common_dir/.." && pwd)"
+    ' "$HOOKS_DIR/pre-commit"
+
+    echo "  ✓ pre-commit hook patched"
+    rm -f "$HOOKS_DIR/pre-commit.bak"
+else
+    echo "  ⚠ pre-commit hook not found. Run 'lefthook install' first."
+    exit 1
+fi
+
+# Fix other hooks if they exist and have the same issue
+for hook in pre-push commit-msg prepare-commit-msg post-commit; do
+    if [ -f "$HOOKS_DIR/$hook" ] && grep -q 'dir="\$(git rev-parse --show-toplevel)"' "$HOOKS_DIR/$hook"; then
+        echo "  Patching $hook hook..."
+        sed -i.bak '
+            /dir="\$(git rev-parse --show-toplevel)"/c\
+    git_common_dir="$(git rev-parse --git-common-dir)"\
+    dir="$(cd "$git_common_dir/.." && pwd)"
+        ' "$HOOKS_DIR/$hook"
+        echo "  ✓ $hook hook patched"
+        rm -f "$HOOKS_DIR/$hook.bak"
+    fi
+done
+
+echo ""
+echo "✅ Lefthook hooks are now compatible with git worktrees!"
+echo ""
+echo "The hooks will now correctly locate the repository root whether running"
+echo "from the main worktree or from a git worktree."


### PR DESCRIPTION
## Summary

Fixes lefthook hooks to work correctly with git worktrees by patching the auto-generated hook scripts to use `git rev-parse --git-common-dir` instead of `git rev-parse --show-toplevel`.

## Problem

Lefthook's auto-generated hooks use `git rev-parse --show-toplevel` to find the repository root. This command returns the worktree directory when running from git worktrees instead of the main repository root, causing hooks to fail with "Can't find lefthook in PATH" errors.

This undermined automatic linting enforcement from issue #37, as our primary workflow uses git worktrees for all development.

## Solution

- **scripts/fix-lefthook-worktree.sh**: Automatic patcher that fixes hook logic
- **package.json**: Updated postinstall to run fix script after `lefthook install`
- **scripts/README.md**: Documentation for the fix script

The script patches hooks to use:
```bash
git_common_dir="$(git rev-parse --git-common-dir)"
dir="$(cd "$git_common_dir/.." && pwd)"
```

This correctly finds the repository root whether running from the main worktree or a git worktree.

## Changes

- `scripts/fix-lefthook-worktree.sh` - Automatic hook patcher script (executable)
- `scripts/README.md` - Documentation for fix script
- `package.json` - Run fix script after lefthook install

## Test Plan

- [x] Script patches hooks successfully
- [x] Lefthook executes from worktree without "Can't find lefthook in PATH" errors
- [x] Hooks correctly locate node_modules in main repository
- [x] Commit hooks run successfully from worktree (verified in commit log)

## What Was Accomplished

✅ Fixed lefthook hooks to work with git worktrees
✅ Automatic patching via postinstall hook
✅ Comprehensive documentation
✅ Tested and verified in actual worktree

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)