### PR TITLE
Add .mcp.json configuration support with gitignore and template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ env/
 .claude/settings.local.json
 *.session.json
 
+# MCP configuration (contains machine-specific paths)
+.mcp.json
+
 # Testing
 .pytest_cache/
 .coverage

--- a/.mcp.json.template
+++ b/.mcp.json.template
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "claude-session-coordinator": {
+      "command": "/path/to/your/python3",
+      "args": [
+        "-m",
+        "claude_session_coordinator"
+      ],
+      "env": {},
+      "cwd": "/path/to/claude_session_coordinator"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -61,21 +61,41 @@ cd packages/mcp-server
 pip install -e .
 ```
 
-### Configuration
+### Quick Start with Claude Code
 
-Add to your Claude Code MCP settings:
+1. Install the MCP server:
+   ```bash
+   cd packages/mcp-server
+   pip install -e ".[dev]"
+   ```
 
-```json
-{
-  "mcpServers": {
-    "session-coordinator": {
-      "command": "python",
-      "args": ["-m", "claude_session_coordinator"],
-      "cwd": "/path/to/your/project"
-    }
-  }
-}
-```
+2. Configure Claude Code:
+   ```bash
+   # Copy the template
+   cp .mcp.json.template .mcp.json
+
+   # Edit with your paths
+   nano .mcp.json
+   ```
+
+3. Update `.mcp.json` with your actual paths:
+   ```json
+   {
+     "mcpServers": {
+       "claude-session-coordinator": {
+         "command": "/path/to/your/python3",
+         "args": [
+           "-m",
+           "claude_session_coordinator"
+         ],
+         "env": {},
+         "cwd": "/path/to/claude_session_coordinator"
+       }
+     }
+   }
+   ```
+
+4. Restart Claude Code - the session coordinator will be available automatically!
 
 ## Features
 

--- a/packages/mcp-server/docs/installation.md
+++ b/packages/mcp-server/docs/installation.md
@@ -107,6 +107,51 @@ You should see output indicating the server has started. Press `Ctrl+C` to stop 
 
 ## Configuration
 
+### Claude Code MCP Configuration
+
+For Claude Code users, the easiest way to configure the MCP server is using the `.mcp.json` file:
+
+1. **Copy the template** (from the repository root):
+   ```bash
+   cp .mcp.json.template .mcp.json
+   ```
+
+2. **Edit the file** with your actual paths:
+   ```bash
+   nano .mcp.json
+   ```
+
+3. **Update the placeholder paths**:
+   ```json
+   {
+     "mcpServers": {
+       "claude-session-coordinator": {
+         "command": "/path/to/your/python3",
+         "args": [
+           "-m",
+           "claude_session_coordinator"
+         ],
+         "env": {},
+         "cwd": "/path/to/claude_session_coordinator"
+       }
+     }
+   }
+   ```
+
+   Replace:
+   - `/path/to/your/python3` - Path to your Python interpreter (e.g., `/home/user/python.dev/bin/python3`)
+   - `/path/to/claude_session_coordinator` - Path to the repository root
+
+4. **Restart Claude Code** - The session coordinator will be available automatically
+
+**Note:** The `.mcp.json` file is gitignored (contains machine-specific paths). Each developer should create their own copy from the template.
+
+### Alternative Configuration Methods
+
+#### MCP Client Configuration Examples
+
+See the [examples/config/](../examples/config/) directory for additional configuration examples for different MCP clients.
+
 ### Default Configuration
 
 By default, the MCP server uses:
@@ -148,7 +193,9 @@ Example configuration file:
 
 After successful installation:
 
-1. **Configure your MCP client** - See [MCP Client Configuration Examples](../examples/config/)
+1. **Configure your MCP client**:
+   - **Claude Code users**: Copy and edit `.mcp.json.template` (see [Claude Code MCP Configuration](#claude-code-mcp-configuration) above)
+   - **Other MCP clients**: See [examples/config/](../examples/config/) for configuration examples
 2. **Read the usage guide** - Learn how to use the session coordination tools
 3. **Start coordinating sessions** - Begin using multiple Claude sessions with shared state
 


### PR DESCRIPTION
## Summary
- Add `.mcp.json` configuration support for Claude Code users
- Create gitignored `.mcp.json` file pattern with template
- Update documentation with setup instructions

## Changes

### Configuration Files
- **`.gitignore`** - Add `.mcp.json` entry (machine-specific paths)
- **`.mcp.json.template`** - Create template with placeholder paths for users to copy and customize

### Documentation Updates
- **`README.md`** - Add "Quick Start with Claude Code" section with step-by-step setup
- **`packages/mcp-server/docs/installation.md`** - Add comprehensive "Claude Code MCP Configuration" section

## Implementation Details

The `.mcp.json` file is gitignored because it contains machine-specific paths (Python interpreter location, project directory) that differ per developer's setup. The template approach allows:
- Easy setup for new users (just copy and edit)
- Clear documentation of expected structure
- Template can be committed (no sensitive/machine-specific data)
- Consistent with how we handle `.claude/settings.local.json`

## Test plan
- [x] `.mcp.json.template` has correct MCP server configuration structure
- [x] Template includes clear placeholder paths that need replacement
- [x] README quick start section provides complete setup workflow
- [x] Installation guide explains template approach and customization
- [x] All acceptance criteria from issue met

## What was accomplished
- All 4 tasks from issue #53 completed
- Improved developer experience for Claude Code users
- Clear documentation for MCP server setup
- Consistent with monorepo configuration patterns

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)